### PR TITLE
Use HTTPS for git submodule URLs so you don't need a github SSH key

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "libs/bevy"]
 	path = libs/bevy
-	url = git@github.com:bevyengine/bevy.git
+	url = https://github.com/bevyengine/bevy.git
 [submodule "libs/bevy_egui"]
 	path = libs/bevy_egui
-	url = git@github.com:Svengali/bevy_egui.git
+	url = https://github.com/Svengali/bevy_egui.git
 [submodule "libs/rust-crdt"]
 	path = libs/rust-crdt
-	url = git@github.com:Svengali/rust-crdt.git
+	url = https://github.com/Svengali/rust-crdt.git
 [submodule "libs/bevy_polyline"]
 	path = libs/bevy_polyline
 	url = https://github.com/Svengali/bevy_polyline.git


### PR DESCRIPTION
Currently the bevy, bevy_egui and rust-crdt submodules use SSH URLs, so someone who doesn't have a Github SSH key set up won't be able to run `git submodule update`. Using HTTPS URLs eliminates this requirement.